### PR TITLE
Fix Netlify build error by setting Astro output to 'server'

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import icon from "astro-icon";
 // https://astro.build/config
 export default defineConfig({
   integrations: [tailwind(), icon()],
-  adapter: netlify()
+  adapter: netlify(),
+  output: "server"
 });
 


### PR DESCRIPTION
## Summary
- Fixed Netlify build failure by adding explicit `output: "server"` configuration to `astro.config.mjs`
- Preserves existing server-side functionality including API routes and pages with `prerender: false`

## Test plan
- [x] Local build passes: `npm run build` completes successfully
- [x] All API routes preserved: `/api/events.ts` and `/api/surprise_pokemon.astro`
- [x] Server-side rendering functionality maintained

🤖 Generated with [Claude Code](https://claude.ai/code)