### PR TITLE
Add Contact page to hamburger menu navigation

### DIFF
--- a/src/components/NavbarDaisy.astro
+++ b/src/components/NavbarDaisy.astro
@@ -16,6 +16,7 @@ import clubicon from "/workspaces/ccsf-cs-club/public/clubicon.png";
             <li><a href="/events/headline">Announcements</a></li>
             <li><a href="/blog">Blog</a></li>
             <li><a href="/events">Calendar</a></li>
+            <li><a href="/contact">Contact</a></li>
             <!-- <li><a href="/subscribe">Subscribe</a></li> -->
           </ul>
         </details>


### PR DESCRIPTION
## Summary
Added Contact link to the Posts dropdown menu in NavbarDaisy component to make the contact page accessible through site navigation. The link points to /contact and maintains consistent styling with existing menu items.

## Changes Made
- Added `<li><a href="/contact">Contact</a></li>` to the Posts dropdown in `src/components/NavbarDaisy.astro`

## Test Plan
- [x] Contact page is accessible via hamburger menu  
- [x] Main navbar layout remains unchanged (no new elements added)
- [x] Mobile navigation continues to work without breaking
- [x] Link is properly styled to match existing menu items
- [x] Build completes successfully with no errors

Fixes #75

🤖 Generated with [Claude Code](https://claude.ai/code)